### PR TITLE
Use a custom time format for RFC3339 for a consistent number of subseconds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 nu-ansi-term = { version = "0.50", optional = true }
-time = { version = "0.3.7", features = ["formatting"] }
+time = { version = "0.3.7", features = ["formatting", "macros"] }
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,6 +2,7 @@ pub(crate) mod builder;
 
 use std::fmt::{self, Write};
 
+use time::format_description::BorrowedFormatItem;
 use tracing::field::Visit;
 use tracing_core::{Event, Field, Subscriber};
 use tracing_subscriber::field::RecordFields;
@@ -68,6 +69,8 @@ fn default_enable_ansi_color() -> bool {
     std::io::stdout().is_terminal()
 }
 
+const TIMESTAMP_FORMAT: &[BorrowedFormatItem<'static>] = time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:6]Z");
+
 impl<S, N> FormatEvent<S, N> for EventsFormatter
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -91,10 +94,12 @@ where
             if self.with_timestamp {
                 serializer.serialize_key("ts")?;
                 serializer.writer.write_char('=')?;
+
+
                 time::OffsetDateTime::now_utc()
                     .format_into(
                         &mut serializer,
-                        &time::format_description::well_known::Rfc3339,
+                        &TIMESTAMP_FORMAT,
                     )
                     .map_err(|_e| fmt::Error)?;
             }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Describe your changes here

### Related Issues

List related issues here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timestamps are now formatted using a custom pattern with six digits of subsecond precision and a trailing 'Z' to indicate UTC.

* **Chores**
  * Updated dependencies to enable macro support for time formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->